### PR TITLE
Fix inaccurate capping

### DIFF
--- a/AllHandsOnDeck.cpp
+++ b/AllHandsOnDeck.cpp
@@ -482,10 +482,12 @@ bool AllHandsOnDeck::enoughHandsOnDeck(bz_eTeamType team, int *flagCarrier, bz_e
             continue;
         }
 
-        if (isPlayerOnDeck(playerID))
+        if (!isPlayerOnDeck(playerID))
         {
-            teamCount++;
+            return false;
         }
+
+        teamCount++;
 
         // Don't override the current flag carrier if the team has multiple enemy flags
         if (*flagCarrier == -1)

--- a/AllHandsOnDeck.cpp
+++ b/AllHandsOnDeck.cpp
@@ -484,6 +484,7 @@ bool AllHandsOnDeck::enoughHandsOnDeck(bz_eTeamType team, int *flagCarrier, bz_e
 
         if (!isPlayerOnDeck(playerID))
         {
+            bz_deleteIntList(playerList);
             return false;
         }
 

--- a/AllHandsOnDeck.cpp
+++ b/AllHandsOnDeck.cpp
@@ -38,7 +38,7 @@ const char* PLUGIN_NAME = "All Hands On Deck!";
 const int MAJOR = 1;
 const int MINOR = 1;
 const int REV = 1;
-const int BUILD = 41;
+const int BUILD = 49;
 
 enum class AhodGameMode
 {


### PR DESCRIPTION
There are incidents when capping is disabled when it shouldn't be. It's probably due to keeping track of team flags manually, this PR will address that issue by instead checking flags when checking for enough hands on deck.

**Cleaned up and ready for merge. Waiting on confirmation that issue was fixed.**